### PR TITLE
Add mod_exists() function to the API

### DIFF
--- a/boomstick_api/helpers.lua
+++ b/boomstick_api/helpers.lua
@@ -68,4 +68,12 @@ function boomstick_api.debug(string, table)
     end
 end
 
-
+--- Returns true if a mod exists
+-- @tparam string modname - The name of a mod.
+-- @return boolean - Whether or not a mod exists.
+function boomstick_api.mod_exists(modname)
+    if minetest.get_modpath(modname) ~= nil then
+        return true
+    end
+    return false
+end


### PR DESCRIPTION
## What
This PR add a function called `mod_exists()` to the API. This is a convenience function to check if a given mod exists.

