### PR TITLE
Add action for deploying docs to gh pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,5 @@
+- name: Deploy docs to Github Pages
+  uses: peaceiris/actions-gh-pages@v3
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    publish_dir: ./boomstick_api/doc/build/


### PR DESCRIPTION
This PR adds a Github Action to auto-deploy docs to a github page.