### PR TITLE
refactor(api/weapon.lua): reordered params for create_new_category

### DIFF
--- a/boomstick_api/weapon.lua
+++ b/boomstick_api/weapon.lua
@@ -172,13 +172,17 @@ function boomstick_api.create_new_weapon(new_weapon_data)
 end
 
 
-function boomstick_api.create_new_category(name, base, category)
-    -- Inherit any default values from a base, if one is provided.
-    if base ~= nil then
+function boomstick_api.create_new_category(name, category, base)
+    -- Inherit any default values from a base, if one is provided. (Ensure both are tables)
+    if base ~= nil and type(base) == "table" and type(category) == "table" then
         category =
             boomstick_api.table_merge(boomstick_api.data.categories[base], category)
+    elseif base ~= nil and type(base) == "table" and type(category) == "string" then
+        -- Because category could be before our table let's reverse the calls so we get the right thing
+        category =
+            boomstick_api.table_merge(boomstick_api.data.categories[category], base)
     end
-
+    --minetest.log("action", minetest.serialize(category)) -- Used to verify the tables were being merged
     boomstick_api.data.categories[name] = category
 end
 
@@ -482,7 +486,7 @@ function boomstick_api.knockback(player, recoil)
 end
 
 
-boomstick_api.create_new_category("weapon", nil, {
+boomstick_api.create_new_category("weapon", {
     rounds_loaded = 0,
     accuracy = 75,
     cycle_cooldown = 0.25,


### PR DESCRIPTION
Reordering the params for create_new_category to support table then optional field, a little bit of confusion as we get the types of category and base to know if we can just merge them or if we need to change them around (appears to merge the tables correctly)

closes #18

## Checklist
- [X] I created an issue first before making this PR. *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
- [X] I playtested this PR with the [Playtesting Checklist](https://github.com/ranguli/boomstick/blob/main/CONTRIBUTING.md) and no known bugs have been created.
- [ ] I tested this PR with `./scripts/run_tests.sh` and no new code quality issues have been created.
> Unable to run test script, don't have `lua-format`. :disappointed:
- [ ] Any new texures or sounds I added have their licensing information entered in [CREDITS.md](https://github.com/ranguli/boomstick/blob/main/CONTRIBUTING.md). *Missing licenses may result in the rejection of the pull request.*
> No new textures
